### PR TITLE
fix: release command

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1296,9 +1296,9 @@
   #define SD_PROCEDURE_DEPTH 1              // Increase if you need more nested M32 calls
 
   #define SD_FINISHED_STEPPERRELEASE true   // Disable steppers when SD Print is finished
-  //#define SD_FINISHED_RELEASECOMMAND "M84"  // Use "M84XYE" to keep Z enabled so your bed stays in place
+  #define SD_FINISHED_RELEASECOMMAND "M84"  // Use "M84XYE" to keep Z enabled so your bed stays in place
 
-#define SD_FINISHED_RELEASECOMMAND "G1 X0 Y145\nM84"   //"M84 X Y Z E" //rock_20210730
+  // #define SD_FINISHED_RELEASECOMMAND "G1 X0 Y145\nM84"   //"M84 X Y Z E" //rock_20210730
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/src/libs/BL24CXX.cpp
+++ b/Marlin/src/libs/BL24CXX.cpp
@@ -209,12 +209,12 @@ void BL24CXX::writeOneByte(uint16_t WriteAddr, uint8_t DataToWrite) {
   else
     IIC::send_byte(EEPROM_DEVICE_ADDRESS + ((WriteAddr >> 8) << 1)); // Send device address 0xA0, write data
 
-    IIC::wait_ack();
-    IIC::send_byte(WriteAddr & 0xFF);               // Send low address
-    IIC::wait_ack();
-    IIC::send_byte(DataToWrite);                    // Receiving mode
-    IIC::wait_ack();
-    IIC::stop();                                    // Generate a stop condition
+  IIC::wait_ack();
+  IIC::send_byte(WriteAddr & 0xFF);               // Send low address
+  IIC::wait_ack();
+  IIC::send_byte(DataToWrite);                    // Receiving mode
+  IIC::wait_ack();
+  IIC::stop();                                    // Generate a stop condition
   delay(10);
 }
 


### PR DESCRIPTION
I've been pulling my hair why my S1 Plus wasn't respecting my end code from my slicer. I realized that after each SD card print, it runs the `SD_FINISHED_RELEASECOMMAND` which for some reason have a `G1` in it. This just pushes the bed to about the middle since S1 Plus is 300x300. I thought it might be better if the user could do what they want for the end code using their preferred slicer. 